### PR TITLE
Update nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -158,8 +158,10 @@ http {
     rewrite ^/products/a-history-of-color$ https://www.sevenstories.com/books/2825-a-history-of-color permanent;
     rewrite ^/products/a-history-of-marriage$ https://www.sevenstories.com/books/2827-a-history-of-marriage permanent;
     rewrite ^/products/a-is-for-activist$ https://www.sevenstories.com/books/2830-a-is-for-activist permanent;
+    rewrite ^/products/a-if-for-activist$ https://www.sevenstories.com/books/2830-a-is-for-activist permanent;
     rewrite ^/products/a-la-caza-del-ultimo-hombre-salvaje$ https://www.sevenstories.com/books/2831-a-la-caza-del-ultimo-hombre-salvaje permanent;
     rewrite ^/products/a-man-without-a-country$ https://www.sevenstories.com/books/2836-a-man-without-a-country permanent;
+    rewrite ^/products/a-man-without-a$ https://www.sevenstories.com/books/2836-a-man-without-a-country permanent;
     rewrite ^/products/a-political-odyssey$ https://www.sevenstories.com/books/2841-a-political-odyssey permanent;
     rewrite ^/products/a-short-course$ https://www.sevenstories.com/books/2843-a-short-course-in-intellectual-self-defense permanent;
     rewrite ^/products/a-sustainable-economy$ https://www.sevenstories.com/books/2845-a-sustainable-economy-for-the-21st-century permanent;


### PR DESCRIPTION
From Noah:

> Two hiccups I want to address off the bat are the redirects for A is for Activist and for A Man Without a Country, two of our biggest books. You'll see in the screenshots attached that the links from our old site don't quite match the links included in the spreadsheet, and so the redirect isn't going through; in the case of A is for Activist, it's that "if" is transposed for "is", and in the case of A Man Without a country it's that the last word of the title is omitted.